### PR TITLE
(Possible) patch to bug arising in CRSMatrix.readExternal

### DIFF
--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -436,7 +436,7 @@ public class CCSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
     }
 
     private int align(int rows, int columns, int cardinality) {
-        return Math.min(rows * columns, ((cardinality % MINIMUM_SIZE) + 1)
+        return Math.min(rows * columns, ((cardinality / MINIMUM_SIZE) + 1)
                         * MINIMUM_SIZE);
     }
 }

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -511,7 +511,7 @@ public class CRSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
     }
 
     private int align(int rows, int columns, int cardinality) {
-        return Math.min(rows * columns, ((cardinality % MINIMUM_SIZE) + 1)
+        return Math.min(rows * columns, ((cardinality / MINIMUM_SIZE) + 1)
                 * MINIMUM_SIZE);
     }
 }


### PR DESCRIPTION
Hi,

I was trying to use writeExternal and readExternal to serialize and deserialize a CRSMatrix, respectively, when I got an ArrayIndexOutOfBoundsException at line 445 of CRSMatrix.java (based on version 0.3.0 of la4j).  After some static code analysis I ended up at the CRSMatrix.align method.  I'm no expert on this stuff, but I would expect a division sign (/) rather than a modulo (%) in there.  I made the change to both CRSMatrix and CCSMatrix and I can now serialize and deserialize successfully.

Hope this helps,
Chandler
