### PR TITLE
Fix downcasting errors

### DIFF
--- a/src/main/java/org/la4j/matrix/sparse/AbstractCompressedMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/AbstractCompressedMatrix.java
@@ -49,10 +49,9 @@ public abstract class AbstractCompressedMatrix extends AbstractMatrix
         return new SparseSafeMatrix(this);
     }
 
-	protected long capacity()
-	{
-		return ((long) rows) * columns;
-	}
+    protected long capacity() {
+        return ((long) rows) * columns;
+    }
 
     protected void ensureCardinalityIsCorrect(long rows, long columns, long cardinality) {
         if (cardinality < 0) {

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -467,8 +467,8 @@ public class CCSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
             throw new IllegalStateException("This matrix can't grow up.");
         }
 
-		int min = rows * columns;
-		min = min < 0 ? Integer.MAX_VALUE : min;
+        int min = rows * columns;
+        min = min < 0 ? Integer.MAX_VALUE : min;
         int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
         double $values[] = new double[capacity];

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -476,9 +476,9 @@ public class CRSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
             throw new IllegalStateException("This matrix can't grow up.");
         }
 
-		int min = rows * columns;
-		min = min < 0 ? Integer.MAX_VALUE : min;
-		int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
+        int min = rows * columns;
+        min = min < 0 ? Integer.MAX_VALUE : min;
+        int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
         double $values[] = new double[capacity];
         int $columnIndices[] = new int[capacity];

--- a/src/test/java/org/la4j/matrix/sparse/SparseMatrixTest.java
+++ b/src/test/java/org/la4j/matrix/sparse/SparseMatrixTest.java
@@ -38,30 +38,26 @@ public abstract class SparseMatrixTest extends AbstractMatrixTest {
         assertEquals(3, a.cardinality());
     }
 
-	public void testLargeMatrix()
-	{
-		int i = 1000000;
-		int j = 2000000;
+    public void testLargeMatrix()
+    {
+        int i = 1000000;
+        int j = 2000000;
 
-		SparseMatrix a = (SparseMatrix) factory().createMatrix(i, j);
+        SparseMatrix a = (SparseMatrix) factory().createMatrix(i, j);
 
-		assertEquals(i, a.rows());
-		assertEquals(j, a.columns());
+        assertEquals(i, a.rows());
+        assertEquals(j, a.columns());
 
-		for(int x = 0; x < i; x += 100000)
-		{
-			for(int y = 0; y < j; y+= 500000)
-			{
-				a.set(x, y, x * y);
-			}
-		}
+        for(int x = 0; x < i; x += 100000) {
+            for(int y = 0; y < j; y+= 500000) {
+                a.set(x, y, x * y);
+            }
+        }
 
-		for(int x = 0; x < i; x += 100000)
-		{
-			for(int y = 0; y < j; y+= 500000)
-			{
-				assertEquals(x * y, (long) a.get(x, y));
-			}
-		}
-	}
+        for(int x = 0; x < i; x += 100000) {
+            for(int y = 0; y < j; y+= 500000) {
+                assertEquals(x * y, (long) a.get(x, y));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Both `CCSMatrix` and `CRSMatrix` don't actually support very large capacities. This is because capacity is calculated by `rows * cols` - and as both are integers, the result overflows.
