### PR TITLE
Adds test and fix for overflow in capacity calculation in resizing sparse matrices.

### DIFF
--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -468,10 +468,12 @@ public class CCSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
             throw new IllegalStateException("This matrix can't grow up.");
         }
 
-        int capacity = ((cardinality * 3) / 2 + 1);
-        if (rows == 0 || columns <= Integer.MAX_VALUE / rows) {
-            capacity = Math.min(capacity, rows * columns);
-        }
+        int min = (
+            (rows != 0 && columns > Integer.MAX_VALUE / rows) ?
+            Integer.MAX_VALUE :
+            (rows * columns)
+            );
+        int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
         double $values[] = new double[capacity];
         int $rowIndices[] = new int[capacity];

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -477,10 +477,12 @@ public class CRSMatrix extends AbstractCompressedMatrix implements SparseMatrix 
             throw new IllegalStateException("This matrix can't grow up.");
         }
 
-        int capacity = ((cardinality * 3) / 2 + 1);
-        if (rows == 0 || columns <= Integer.MAX_VALUE / rows) {
-            capacity = Math.min(capacity, rows * columns);
-        }
+        int min = (
+            (rows != 0 && columns > Integer.MAX_VALUE / rows) ?
+            Integer.MAX_VALUE :
+            (rows * columns)
+            );
+        int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
         double $values[] = new double[capacity];
         int $columnIndices[] = new int[capacity];

--- a/src/test/java/org/la4j/matrix/sparse/SparseMatrixTest.java
+++ b/src/test/java/org/la4j/matrix/sparse/SparseMatrixTest.java
@@ -62,11 +62,11 @@ public abstract class SparseMatrixTest extends AbstractMatrixTest {
     }
 
     public void testCapacityOverflow() {
-        int i = 214748365;
-        int j = 20;
+        int i = 65536;
+        int j = 65536;
 
-        // Integer 214748365 * 20 overflows to 4
-        assertEquals(4, i * j);
+        // Integer 65536 * 65536 overflows to 0
+        assertEquals(0, i * j);
 
         SparseMatrix a = (SparseMatrix) factory().createMatrix(i, j);
 
@@ -81,7 +81,7 @@ public abstract class SparseMatrixTest extends AbstractMatrixTest {
 
         // Since values and Indices array sizes are align'd with CCSMatrix and
         //  CRSMatrix.MINIMUM_SIZE (=32), we need to set more than 32 values.
-        for(int row = 0 ; row < 31 ; row++) {
+        for(int row = 0 ; row < 32 ; row++) {
             a.set(row, 1, 3.1415);
         }
     }


### PR DESCRIPTION
For large integer overflow, checking if result is below zero is not enough.
Even for fairly small matrices (~ 65000 x 65000) this is a problem.
