### PR TITLE
Fixed typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ la4j-0.5.0 `Apr 2014`
  * Tests migrated to latest junit version, removed `MockVector` and `MockMatrix` classes (contributed by Maxim Samoylov)
  * New vector method `equals(vector, precision)`
  * New matrix method `equals(matrix, precision)`
- * New vector method `normalize(vectorAccumulator`
+ * New vector method `normalize(vectorAccumulator)`
  * New vector method `normalize()`
  * Added index range checks for `SparseVector`
  * Added index range checks for `Basic1DMatrix`, `CRSMatrix`, and `CCSMatrix`


### PR DESCRIPTION
Noticed a missing `)` in the CHANGELOG file.
