### PR TITLE
Fixed matrix insert validation. Fix #255

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -732,7 +732,7 @@ public abstract class Matrix implements Iterable<Double> {
             fail("Cannot have negative destination position: " + destRow + ", " + destColumn);
         }
 
-        if (destRow > that.rows() || destColumn> that.columns()) {
+        if (destRow > this.rows || destColumn > this.columns) {
             fail("Destination position out of bounds: " + destRow + ", " + destColumn);
         }
 
@@ -740,18 +740,18 @@ public abstract class Matrix implements Iterable<Double> {
             fail("Cannot have negative source position: " + destRow + ", " + destColumn);
         }
 
-        if (srcRow > this.rows || srcColumn > this.columns) {
+        if (srcRow > that.rows || srcColumn > that.columns) {
             fail("Destination position out of bounds: " + srcRow + ", " + srcColumn);
         }
 
-        if (destRow + rows > this.columns || destColumn + columns > this.rows) {
+        if (destRow + rows > this.rows || destColumn + columns > this.columns) {
             fail("Out of bounds: Cannot add " + rows + " rows and " + columns + " cols at "
                     + destRow + ", " + destColumn + " in a " + this.rows + "x" + this.columns + " matrix.");
         }
 
-        if (srcRow + rows > that.rows() || srcColumn + columns > that.columns()) {
+        if (srcRow + rows > that.rows || srcColumn + columns > that.columns) {
             fail("Out of bounds: Cannot get " + rows + " rows and " + columns + " cols at "
-                    + srcRow + ", " + srcColumn + " from a " + that.rows() + "x" + that.columns() + " matrix.");
+                    + srcRow + ", " + srcColumn + " from a " + that.rows + "x" + that.columns + " matrix.");
         }
 
         Matrix result = copy();

--- a/src/test/java/org/la4j/matrix/MatrixTest.java
+++ b/src/test/java/org/la4j/matrix/MatrixTest.java
@@ -103,6 +103,26 @@ public abstract class MatrixTest<T extends Matrix> {
         
         Assert.assertEquals(a, b.insert(a, 1, 1, a.rows(), a.columns()).slice(1, 1, 3, 3));
     }
+
+    @Test
+    public void testInsert_3x1_into_3x3_offset() {
+        Matrix a = m(a(1.0),
+                     a(2.0),
+                     a(3.0));
+
+        Matrix b = mz(3, 3);
+
+        Assert.assertEquals(a, b.insert(a, 0, 2, a.rows(), a.columns()).slice(0, 2, 3, 3));
+    }
+
+    @Test
+    public void testInsert_1x3_into_3x3_offset() {
+        Matrix a = m(a(1.0, 2.0, 3.0));
+
+        Matrix b = mz(3, 3);
+
+        Assert.assertEquals(a, b.insert(a, 2, 0, a.rows(), a.columns()).slice(2, 0, 3, 3));
+    }
     
     @Test
     public void testAccess_3x3() {


### PR DESCRIPTION
Fixed two cases where rows and columns and source and destination matrices were mixed up.  Added two new tests to test inserting asymmetric matrices with an offset.