### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the variable

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -932,7 +932,7 @@ public abstract class Matrix implements Iterable<Double> {
         }
 
         MatrixDecompositor decompositor = withDecompositor(LinearAlgebra.LU);
-        Matrix lup[] = decompositor.decompose();
+        Matrix[] lup = decompositor.decompose();
         // TODO: Why Java doesn't support pattern matching?
         Matrix u = lup[1];
         Matrix p = lup[2];
@@ -941,7 +941,7 @@ public abstract class Matrix implements Iterable<Double> {
 
         // TODO: we can do that in O(n log n)
         //       just google: "counting inversions divide and conqueror"
-        int permutations[] = new int[p.rows()];
+        int[] permutations = new int[p.rows()];
         for (int i = 0; i < p.rows(); i++) {
             for (int j = 0; j < p.columns(); j++) {
                 if (p.get(i, j) > 0.0) {
@@ -983,7 +983,7 @@ public abstract class Matrix implements Iterable<Double> {
         // matrices without SVD
 
         MatrixDecompositor decompositor = withDecompositor(LinearAlgebra.SVD);
-        Matrix usv[] = decompositor.decompose();
+        Matrix[] usv = decompositor.decompose();
         // TODO: Where is my pattern matching?
         Matrix s = usv[1];
         double tolerance = Math.max(rows, columns) * s.get(0, 0) * Matrices.EPS;
@@ -1812,7 +1812,7 @@ public abstract class Matrix implements Iterable<Double> {
      */
     public String mkString(NumberFormat formatter, String rowsDelimiter, String columnsDelimiter) {
         // TODO: rewrite using iterators
-        int formats[] = new int[columns];
+        int[] formats = new int[columns];
 
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {

--- a/src/main/java/org/la4j/decomposition/EigenDecompositor.java
+++ b/src/main/java/org/la4j/decomposition/EigenDecompositor.java
@@ -701,7 +701,7 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
                     H.set(n - 1, n, -(H.get(n, n) - p) 
                                             / H.get(n, n - 1));
                 } else {
-                    double cdiv[] = cdiv(0.0, -H.get(n - 1, n), 
+                    double[] cdiv = cdiv(0.0, -H.get(n - 1, n),
                          H.get(n - 1, n - 1) - p, q);
                     H.set(n - 1, n - 1, cdiv[0]);
                     H.set(n - 1, n, cdiv[1]);
@@ -725,7 +725,7 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
                     } else {
                         l = i;
                         if (e.get(i) == 0) {
-                            double cdiv[] = cdiv(-ra, -sa, w, q);
+                            double[] cdiv = cdiv(-ra, -sa, w, q);
                             H.set(i, n - 1, cdiv[0]);
                             H.set(i, n, cdiv[1]);
                         } else {
@@ -744,7 +744,7 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
                                                 + Math.abs(x) + Math.abs(y) + Math
                                                     .abs(z));
                             }
-                            double cdiv[] = cdiv(x * r - z * ra + q * sa, 
+                            double[] cdiv = cdiv(x * r - z * ra + q * sa,
                                                  x * s - z * sa - q * ra, vr, vi);
                             H.set(i, n - 1, cdiv[0]);
                             H.set(i, n, cdiv[1]);

--- a/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
@@ -48,7 +48,7 @@ public class Basic1DMatrix extends DenseMatrix {
      * Creates a constant {@link Basic1DMatrix} of the given shape and {@code value}.
      */
     public static Basic1DMatrix constant(int rows, int columns, double constant) {
-        double array[] = new double[rows * columns];
+        double[] array = new double[rows * columns];
         Arrays.fill(array, constant);
 
         return new Basic1DMatrix(rows, columns, array);
@@ -59,7 +59,7 @@ public class Basic1DMatrix extends DenseMatrix {
      * diagonal elements are equal to {@code diagonal}.
      */
     public static Basic1DMatrix diagonal(int size, double diagonal) {
-        double array[] = new double[size * size];
+        double[] array = new double[size * size];
 
         for (int i = 0; i < size; i++) {
             array[i * size + i] = diagonal;
@@ -88,7 +88,7 @@ public class Basic1DMatrix extends DenseMatrix {
      * {@code rows} x {@code columns}.
      */
     public static Basic1DMatrix random(int rows, int columns, Random random) {
-        double array[] = new double[rows * columns];
+        double[] array = new double[rows * columns];
 
         for (int i = 0; i < rows * columns; i++) {
             array[i] = random.nextDouble();
@@ -101,7 +101,7 @@ public class Basic1DMatrix extends DenseMatrix {
      * Creates a random symmetric {@link Basic1DMatrix} of the given {@code size}.
      */
     public static Basic1DMatrix randomSymmetric(int size, Random random) {
-        double array[] = new double[size * size];
+        double[] array = new double[size * size];
 
         for (int i = 0; i < size; i++) {
             for (int j = i; j < size; j++) {
@@ -151,7 +151,7 @@ public class Basic1DMatrix extends DenseMatrix {
         }
 
         int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
-        double array[] = new double[rows * columns];
+        double[] array = new double[rows * columns];
 
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {
@@ -221,7 +221,7 @@ public class Basic1DMatrix extends DenseMatrix {
         return Matrix.fromMatrixMarket(mm).to(Matrices.BASIC_1D);
     }
 
-    private double self[];
+    private double[] self;
 
     public Basic1DMatrix() {
         this(0, 0);
@@ -231,7 +231,7 @@ public class Basic1DMatrix extends DenseMatrix {
         this(rows, columns, new double[rows * columns]);
     }
 
-    public Basic1DMatrix(int rows, int columns, double array[]) {
+    public Basic1DMatrix(int rows, int columns, double[] array) {
         super(rows, columns);
         this.self = array;
     }
@@ -277,7 +277,7 @@ public class Basic1DMatrix extends DenseMatrix {
 
     @Override
     public Vector getRow(int i) {
-        double result[] = new double[columns];
+        double[] result = new double[columns];
         System.arraycopy(self, i * columns , result, 0, columns);
 
         return new BasicVector(result);
@@ -288,7 +288,7 @@ public class Basic1DMatrix extends DenseMatrix {
         ensureDimensionsAreCorrect(rows, columns);
 
         if (this.rows < rows && this.columns == columns) {
-            double $self[] = new double[rows * columns];
+            double[] $self = new double[rows * columns];
             System.arraycopy(self, 0, $self, 0, this.rows * columns);
 
             return new Basic1DMatrix(rows, columns, $self);
@@ -310,7 +310,7 @@ public class Basic1DMatrix extends DenseMatrix {
     @Override
     public double[][] toArray() {
 
-        double result[][] = new double[rows][columns];
+        double[][] result = new double[rows][columns];
 
         int offset = 0;
         for (int i = 0; i < rows; i++) {

--- a/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
@@ -48,7 +48,7 @@ public class Basic2DMatrix extends DenseMatrix {
      * Creates a constant {@link Basic2DMatrix} of the given shape and {@code value}.
      */
     public static Basic2DMatrix constant(int rows, int columns, double constant) {
-        double array[][] = new double[rows][columns];
+        double[][] array = new double[rows][columns];
 
         for (int i = 0; i < rows; i++) {
             Arrays.fill(array[i], constant);
@@ -62,7 +62,7 @@ public class Basic2DMatrix extends DenseMatrix {
      * diagonal elements are equal to {@code diagonal}.
      */
     public static Basic2DMatrix diagonal(int size, double diagonal) {
-        double array[][] = new double[size][size];
+        double[][] array = new double[size][size];
 
         for (int i = 0; i < size; i++) {
             array[i][i] = diagonal;
@@ -91,7 +91,7 @@ public class Basic2DMatrix extends DenseMatrix {
      * {@code rows} x {@code columns}.
      */
     public static Basic2DMatrix random(int rows, int columns, Random random) {
-        double array[][] = new double[rows][columns];
+        double[][] array = new double[rows][columns];
 
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {
@@ -106,7 +106,7 @@ public class Basic2DMatrix extends DenseMatrix {
      * Creates a random symmetric {@link Basic2DMatrix} of the given {@code size}.
      */
     public static Basic2DMatrix randomSymmetric(int size, Random random) {
-        double array[][] = new double[size][size];
+        double[][] array = new double[size][size];
 
         for (int i = 0; i < size; i++) {
             for (int j = i; j < size; j++) {
@@ -152,7 +152,7 @@ public class Basic2DMatrix extends DenseMatrix {
         }
 
         int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
-        double array[][] = new double[rows][columns];
+        double[][] array = new double[rows][columns];
 
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {
@@ -223,7 +223,7 @@ public class Basic2DMatrix extends DenseMatrix {
         return Matrix.fromMatrixMarket(mm).to(Matrices.BASIC_2D);
     }
 
-    private double self[][];
+    private double[][] self;
 
     public Basic2DMatrix() {
         this(0, 0);
@@ -233,7 +233,7 @@ public class Basic2DMatrix extends DenseMatrix {
         this(new double[rows][columns]);
     }
 
-    public Basic2DMatrix(double array[][]) {
+    public Basic2DMatrix(double[][] array) {
         super(array.length, array.length == 0 ? 0: array[0].length);
         this.self = array;
     }
@@ -258,7 +258,7 @@ public class Basic2DMatrix extends DenseMatrix {
     @Override
     public void swapRows(int i, int j) {
         if (i != j) {
-            double tmp[] = self[i];
+            double[] tmp = self[i];
             self[i] = self[j];
             self[j] = tmp;
         }
@@ -277,7 +277,7 @@ public class Basic2DMatrix extends DenseMatrix {
 
     @Override
     public Vector getRow(int i) {
-        double result[] = new double[columns];
+        double[] result = new double[columns];
         System.arraycopy(self[i], 0, result, 0, columns);
 
         return new BasicVector(result);
@@ -287,7 +287,7 @@ public class Basic2DMatrix extends DenseMatrix {
     public Matrix copyOfShape(int rows, int columns) {
         ensureDimensionsAreCorrect(rows, columns);
 
-        double $self[][] = new double[rows][columns];
+        double[][] $self = new double[rows][columns];
         for (int i = 0; i < Math.min(this.rows, rows); i++) {
             System.arraycopy(self[i], 0, $self[i], 0, Math.min(this.columns, columns));
         }
@@ -297,7 +297,7 @@ public class Basic2DMatrix extends DenseMatrix {
 
     @Override
     public double[][] toArray() {
-        double result[][] = new double[rows][columns];
+        double[][] result = new double[rows][columns];
 
         for (int i = 0; i < rows; i++) {
             System.arraycopy(self[i], 0, result[i], 0, columns);

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -70,9 +70,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
      * diagonal elements are equal to {@code diagonal}.
      */
     public static CCSMatrix diagonal(int size, double diagonal) {
-        double values[] = new double[size];
-        int rowIndices[] = new int[size];
-        int columnPointers[] = new int[size + 1];
+        double[] values = new double[size];
+        int[] rowIndices = new int[size];
+        int[] columnPointers = new int[size + 1];
 
         for (int i = 0; i < size; i++) {
             rowIndices[i] = i;
@@ -103,12 +103,12 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
         int cardinality = Math.max((int)((rows * columns) * density), columns);
 
-        double values[] = new double[cardinality];
-        int rowIndices[] = new int[cardinality];
-        int columnPointers[] = new int[columns + 1];
+        double[] values = new double[cardinality];
+        int[] rowIndices = new int[cardinality];
+        int[] columnPointers = new int[columns + 1];
 
         int kk = cardinality / columns;
-        int indices[] = new int[kk];
+        int[] indices = new int[kk];
 
         int k = 0;
         for (int j = 0; j < columns; j++) {
@@ -218,7 +218,7 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
         int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
         ArrayList<Double> values = new ArrayList<Double>();
         ArrayList<Integer> rowIndices = new ArrayList<Integer>();
-        int columnPointers[] = new int[rows + 1];
+        int[] columnPointers = new int[rows + 1];
 
         int k = 0;
         columnPointers[0] = 0;
@@ -245,8 +245,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
             }
             columnPointers[i + 1] = k;
         }
-        double valuesArray[] = new double[values.size()];
-        int rowIndArray[] = new int[rowIndices.size()];
+        double[] valuesArray = new double[values.size()];
+        int[] rowIndArray = new int[rowIndices.size()];
         for (int i = 0; i < values.size(); i++) {
             valuesArray[i] = values.get(i);
             rowIndArray[i] = rowIndices.get(i);
@@ -313,9 +313,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
     private static final int MINIMUM_SIZE = 32;
 
-    private double values[];
-    private int rowIndices[];
-    private int columnPointers[];
+    private double[] values;
+    private int[] rowIndices;
+    private int[] columnPointers;
 
     public CCSMatrix() {
         this(0, 0);
@@ -335,7 +335,7 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
         this.columnPointers = new int[columns + 1];
     }
 
-    public CCSMatrix(int rows, int columns, int cardinality, double values[], int rowIndices[], int columnPointers[]) {
+    public CCSMatrix(int rows, int columns, int cardinality, double[] values, int[] rowIndices, int[] columnPointers) {
         super(rows, columns, cardinality);
         ensureCardinalityIsCorrect(rows, columns, cardinality);
 
@@ -402,8 +402,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
     @Override
     public Vector getColumn(int j) {
         int columnCardinality = columnPointers[j + 1] - columnPointers[j];
-        double columnValues[] = new double[columnCardinality];
-        int columnIndices[] = new int[columnCardinality];
+        double[] columnValues = new double[columnCardinality];
+        int[] columnIndices = new int[columnCardinality];
 
         System.arraycopy(values, columnPointers[j], columnValues, 0, 
                          columnCardinality);
@@ -436,9 +436,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
         ensureDimensionsAreCorrect(rows, columns);
 
         if (rows >= this.rows && columns >= this.columns) {
-            double $values[] = new double[align(cardinality)];
-            int $rowIndices[] = new int[align(cardinality)];
-            int $columnPointers[] = new int[columns + 1];
+            double[] $values = new double[align(cardinality)];
+            int[] $rowIndices = new int[align(cardinality)];
+            int[] $columnPointers = new int[columns + 1];
 
             System.arraycopy(values, 0, $values, 0, cardinality);
             System.arraycopy(rowIndices, 0, $rowIndices, 0, cardinality);
@@ -451,9 +451,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
             return new CCSMatrix(rows, columns, cardinality, $values, $rowIndices, $columnPointers);
         }
 
-        double $values[] = new double[align(cardinality)];
-        int $rowIndices[] = new int[align(cardinality)];
-        int $columnPointers[] = new int[columns + 1];
+        double[] $values = new double[align(cardinality)];
+        int[] $rowIndices = new int[align(cardinality)];
+        int[] $columnPointers = new int[columns + 1];
 
         int $cardinality = 0;
 
@@ -631,8 +631,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
             );
         int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
-        double $values[] = new double[capacity];
-        int $rowIndices[] = new int[capacity];
+        double[] $values = new double[capacity];
+        int[] $rowIndices = new int[capacity];
 
         System.arraycopy(values, 0, $values, 0, cardinality);
         System.arraycopy(rowIndices, 0, $rowIndices, 0, cardinality);

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -71,9 +71,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
      * diagonal elements are equal to {@code diagonal}.
      */
     public static CRSMatrix diagonal(int size, double diagonal) {
-        double values[] = new double[size];
-        int columnIndices[] = new int[size];
-        int rowPointers[] = new int[size + 1];
+        double[] values = new double[size];
+        int[] columnIndices = new int[size];
+        int[] rowPointers = new int[size + 1];
 
         for (int i = 0; i < size; i++) {
             columnIndices[i] = i;
@@ -104,12 +104,12 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
         int cardinality = Math.max((int) ((rows * columns) * density), rows);
 
-        double values[] = new double[cardinality];
-        int columnIndices[] = new int[cardinality];
-        int rowPointers[] = new int[rows + 1];
+        double[] values = new double[cardinality];
+        int[] columnIndices = new int[cardinality];
+        int[] rowPointers = new int[rows + 1];
 
         int kk = cardinality / rows;
-        int indices[] = new int[kk];
+        int[] indices = new int[kk];
 
         int k = 0;
         for (int i = 0; i < rows; i++) {
@@ -219,7 +219,7 @@ public class CRSMatrix extends RowMajorSparseMatrix {
         int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
         ArrayList<Double> values = new ArrayList<Double>();
         ArrayList<Integer> columnIndices = new ArrayList<Integer>();
-        int rowPointers[] = new int[rows + 1];
+        int[] rowPointers = new int[rows + 1];
 
         int k = 0;
         rowPointers[0] = 0;
@@ -246,8 +246,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
             }
             rowPointers[i + 1] = k;
         }
-        double valuesArray[] = new double[values.size()];
-        int colIndArray[] = new int[columnIndices.size()];
+        double[] valuesArray = new double[values.size()];
+        int[] colIndArray = new int[columnIndices.size()];
         for (int i = 0; i < values.size(); i++) {
             valuesArray[i] = values.get(i);
             colIndArray[i] = columnIndices.get(i);
@@ -314,9 +314,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
     private static final int MINIMUM_SIZE = 32;
 
-    private double values[];
-    private int columnIndices[];
-    private int rowPointers[];
+    private double[] values;
+    private int[] columnIndices;
+    private int[] rowPointers;
 
     public CRSMatrix() {
         this(0, 0);
@@ -336,7 +336,7 @@ public class CRSMatrix extends RowMajorSparseMatrix {
         this.rowPointers = new int[rows + 1];
     }
 
-    public CRSMatrix(int rows, int columns, int cardinality, double values[], int columnIndices[], int rowPointers[]) {
+    public CRSMatrix(int rows, int columns, int cardinality, double[] values, int[] columnIndices, int[] rowPointers) {
         super(rows, columns, cardinality);
         ensureCardinalityIsCorrect(rows, columns, cardinality);
 
@@ -403,8 +403,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
     @Override
     public Vector getRow(int i) {
         int rowCardinality = rowPointers[i + 1] - rowPointers[i];
-        double rowValues[] = new double[rowCardinality];
-        int rowIndices[] = new int[rowCardinality];
+        double[] rowValues = new double[rowCardinality];
+        int[] rowIndices = new int[rowCardinality];
 
         System.arraycopy(values, rowPointers[i], rowValues, 0, rowCardinality);
         System.arraycopy(columnIndices, rowPointers[i], rowIndices, 
@@ -436,9 +436,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
         ensureDimensionsAreCorrect(rows, columns);
 
         if (rows >= this.rows && columns >= this.columns) {
-            double $values[] = new double[align(cardinality)];
-            int $columnIndices[] = new int[align(cardinality)];
-            int $rowPointers[] = new int[rows + 1];
+            double[] $values = new double[align(cardinality)];
+            int[] $columnIndices = new int[align(cardinality)];
+            int[] $rowPointers = new int[rows + 1];
 
             System.arraycopy(values, 0, $values, 0, cardinality);
             System.arraycopy(columnIndices, 0, $columnIndices, 0, cardinality);
@@ -451,9 +451,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
             return new CRSMatrix(rows, columns, cardinality, $values, $columnIndices, $rowPointers);
         }
 
-        double $values[] = new double[align(cardinality)];
-        int $columnIndices[] = new int[align(cardinality)];
-        int $rowPointers[] = new int[rows + 1];
+        double[] $values = new double[align(cardinality)];
+        int[] $columnIndices = new int[align(cardinality)];
+        int[] $rowPointers = new int[rows + 1];
 
         int $cardinality = 0;
 
@@ -630,8 +630,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
             );
         int capacity = Math.min(min, (cardinality * 3) / 2 + 1);
 
-        double $values[] = new double[capacity];
-        int $columnIndices[] = new int[capacity];
+        double[] $values = new double[capacity];
+        int[] $columnIndices = new int[capacity];
 
         System.arraycopy(values, 0, $values, 0, cardinality);
         System.arraycopy(columnIndices, 0, $columnIndices, 0, cardinality);

--- a/src/main/java/org/la4j/vector/dense/BasicVector.java
+++ b/src/main/java/org/la4j/vector/dense/BasicVector.java
@@ -63,7 +63,7 @@ public class BasicVector extends DenseVector {
      * the given {@code value}.
      */
     public static BasicVector constant(int length, double value) {
-        double array[] = new double[length];
+        double[] array = new double[length];
         Arrays.fill(array, value);
 
         return new BasicVector(array);
@@ -81,7 +81,7 @@ public class BasicVector extends DenseVector {
      * the given {@code Random}.
      */
     public static BasicVector random(int length, Random random) {
-        double array[] = new double[length];
+        double[] array = new double[length];
         for (int i = 0; i < length; i++) {
             array[i] = random.nextDouble();
         }
@@ -172,7 +172,7 @@ public class BasicVector extends DenseVector {
         return Vector.fromMap(map, length).to(Vectors.BASIC);
     }
 
-    private double self[];
+    private double[] self;
 
     public BasicVector() {
         this(0);
@@ -182,7 +182,7 @@ public class BasicVector extends DenseVector {
         this(new double[length]);
     }
 
-    public BasicVector(double array[]) {
+    public BasicVector(double[] array) {
         super(array.length);
         this.self = array;
     }
@@ -210,7 +210,7 @@ public class BasicVector extends DenseVector {
     public Vector copyOfLength(int length) {
       ensureLengthIsCorrect(length);
 
-      double $self[] = new double[length];
+      double[] $self = new double[length];
       System.arraycopy(self, 0, $self, 0, Math.min($self.length, self.length));
 
       return new BasicVector($self);
@@ -218,7 +218,7 @@ public class BasicVector extends DenseVector {
 
     @Override
     public double[] toArray() {
-        double result[] = new double[length];
+        double[] result = new double[length];
         System.arraycopy(self, 0, result, 0, length);
         return result;
     }

--- a/src/main/java/org/la4j/vector/sparse/CompressedVector.java
+++ b/src/main/java/org/la4j/vector/sparse/CompressedVector.java
@@ -85,8 +85,8 @@ public class CompressedVector extends SparseVector {
         }
 
         int cardinality = (int) (length * density);
-        double values[] = new double[cardinality];
-        int indices[] = new int[cardinality];
+        double[] values = new double[cardinality];
+        int[] indices = new int[cardinality];
 
         for (int i = 0; i < cardinality; i++) {
             values[i] = random.nextDouble();
@@ -202,8 +202,8 @@ public class CompressedVector extends SparseVector {
         return new CompressedVector(length, cardinality, values, indices);
     }
 
-    private double values[];
-    private int indices[];
+    private double[] values;
+    private int[] indices;
 
     public CompressedVector() {
         this(0);
@@ -220,7 +220,7 @@ public class CompressedVector extends SparseVector {
         this.indices = new int[alignedSize];
     }
 
-    public CompressedVector(int length, int cardinality, double values[], int indices[]) {
+    public CompressedVector(int length, int cardinality, double[] values, int[] indices) {
         super(length, cardinality);
         this.values = values;
         this.indices = indices;
@@ -343,8 +343,8 @@ public class CompressedVector extends SparseVector {
             cardinality : searchForIndex(length);
         int capacity = align(length, $cardinality);
 
-        double $values[] = new double[capacity];
-        int $indices[] = new int[capacity];
+        double[] $values = new double[capacity];
+        int[] $indices = new int[capacity];
 
         System.arraycopy(values, 0, $values, 0, $cardinality);
         System.arraycopy(indices, 0, $indices, 0, $cardinality);
@@ -509,8 +509,8 @@ public class CompressedVector extends SparseVector {
 
         int capacity = Math.min(length, (cardinality * 3) / 2 + 1);
 
-        double $values[] = new double[capacity];
-        int $indices[] = new int[capacity];
+        double[] $values = new double[capacity];
+        int[] $indices = new int[capacity];
 
         System.arraycopy(values, 0, $values, 0, cardinality);
         System.arraycopy(indices, 0, $indices, 0, cardinality);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava