### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -82,6 +82,25 @@ public abstract class Matrix implements Iterable<Double> {
             "          "
     };
 
+    protected int rows;
+    protected int columns;
+
+    /**
+     * Creates a zero-shape matrix.
+     */
+    public Matrix() {
+        this(0, 0);
+    }
+
+    /**
+     * Creates a matrix of given shape {@code rows} x {@code columns};
+     */
+    public Matrix(int rows, int columns) {
+        ensureDimensionsAreCorrect(rows, columns);
+        this.rows = rows;
+        this.columns = columns;
+    }
+
     /**
      * Creates a zero {@link Matrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -275,25 +294,6 @@ public abstract class Matrix implements Iterable<Double> {
 
             return result;
         }
-    }
-
-    protected int rows;
-    protected int columns;
-
-    /**
-     * Creates a zero-shape matrix.
-     */
-    public Matrix() {
-        this(0, 0);
-    }
-
-    /**
-     * Creates a matrix of given shape {@code rows} x {@code columns};
-     */
-    public Matrix(int rows, int columns) {
-        ensureDimensionsAreCorrect(rows, columns);
-        this.rows = rows;
-        this.columns = columns;
     }
 
     //

--- a/src/main/java/org/la4j/Vector.java
+++ b/src/main/java/org/la4j/Vector.java
@@ -53,6 +53,28 @@ public abstract class Vector implements Iterable<Double> {
     private static final NumberFormat DEFAULT_FORMATTER = new DecimalFormat("0.000");
 
     /**
+     * Length of this vector.
+     */
+    protected int length;
+
+    /**
+     * Creates a vector of zero length.
+     */
+    public Vector() {
+        this(0);
+    }
+
+    /**
+     * Creates a vector of given {@code length}.
+     *
+     * @param length the length of the vector
+     */
+    public Vector(int length) {
+        ensureLengthIsCorrect(length);
+        this.length = length;
+    }
+
+    /**
      * Creates a zero {@link Vector} of the given {@code length}.
      */
     public static Vector zero(int length) {
@@ -181,28 +203,6 @@ public abstract class Vector implements Iterable<Double> {
      */
     public static Vector fromMap(Map<Integer, ? extends Number> map, int length) {
         return SparseVector.fromMap(map, length);
-    }
-
-    /**
-     * Length of this vector.
-     */
-    protected int length;
-
-    /**
-     * Creates a vector of zero length.
-     */
-    public Vector() {
-        this(0);
-    }
-
-    /**
-     * Creates a vector of given {@code length}.
-     *
-     * @param length the length of the vector
-     */
-    public Vector(int length) {
-        ensureLengthIsCorrect(length);
-        this.length = length;
     }
 
     //

--- a/src/main/java/org/la4j/iterator/JoinFunction.java
+++ b/src/main/java/org/la4j/iterator/JoinFunction.java
@@ -24,8 +24,6 @@ package org.la4j.iterator;
 // TODO: need a better name
 abstract class JoinFunction {
 
-    public abstract double apply(double a, double b);
-
     public static final JoinFunction ADD = new JoinFunction() {
         @Override
         public double apply(double a, double b) {
@@ -60,4 +58,6 @@ abstract class JoinFunction {
             return a % b;
         }
     };
+
+    public abstract double apply(double a, double b);
 }

--- a/src/main/java/org/la4j/matrix/ColumnMajorSparseMatrix.java
+++ b/src/main/java/org/la4j/matrix/ColumnMajorSparseMatrix.java
@@ -36,6 +36,14 @@ import java.util.Random;
 
 public abstract class ColumnMajorSparseMatrix extends SparseMatrix {
 
+    public ColumnMajorSparseMatrix(int rows, int columns) {
+        super(rows, columns);
+    }
+
+    public ColumnMajorSparseMatrix(int rows, int columns, int cardinality) {
+        super(rows, columns, cardinality);
+    }
+
     /**
      * Creates a zero {@link ColumnMajorSparseMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -126,14 +134,6 @@ public abstract class ColumnMajorSparseMatrix extends SparseMatrix {
      */
     public static ColumnMajorSparseMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.SPARSE_COLUMN_MAJOR);
-    }
-
-    public ColumnMajorSparseMatrix(int rows, int columns) {
-        super(rows, columns);
-    }
-
-    public ColumnMajorSparseMatrix(int rows, int columns, int cardinality) {
-        super(rows, columns, cardinality);
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/DenseMatrix.java
+++ b/src/main/java/org/la4j/matrix/DenseMatrix.java
@@ -36,6 +36,10 @@ import java.util.Random;
 
 public abstract class DenseMatrix extends Matrix {
 
+    public DenseMatrix(int rows, int columns) {
+        super(rows, columns);
+    }
+
     /**
      * Creates a zero {@link DenseMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -133,10 +137,6 @@ public abstract class DenseMatrix extends Matrix {
      */
     public static DenseMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.DENSE);
-    }
-
-    public DenseMatrix(int rows, int columns) {
-        super(rows, columns);
     }
 
     /**

--- a/src/main/java/org/la4j/matrix/RowMajorSparseMatrix.java
+++ b/src/main/java/org/la4j/matrix/RowMajorSparseMatrix.java
@@ -38,6 +38,14 @@ import java.util.Random;
 
 public abstract class RowMajorSparseMatrix extends SparseMatrix {
 
+    public RowMajorSparseMatrix(int rows, int columns) {
+        super(rows, columns);
+    }
+
+    public RowMajorSparseMatrix(int rows, int columns, int cardinality) {
+        super(rows, columns, cardinality);
+    }
+
     /**
      * Creates a zero {@link RowMajorSparseMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -128,14 +136,6 @@ public abstract class RowMajorSparseMatrix extends SparseMatrix {
      */
     public static RowMajorSparseMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.SPARSE_ROW_MAJOR);
-    }
-
-    public RowMajorSparseMatrix(int rows, int columns) {
-        super(rows, columns);
-    }
-
-    public RowMajorSparseMatrix(int rows, int columns, int cardinality) {
-        super(rows, columns, cardinality);
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/SparseMatrix.java
+++ b/src/main/java/org/la4j/matrix/SparseMatrix.java
@@ -42,6 +42,17 @@ import java.util.Random;
 
 public abstract class SparseMatrix extends Matrix {
 
+    protected int cardinality;
+
+    public SparseMatrix(int rows, int columns) {
+        this(rows, columns, 0);
+    }
+
+    public SparseMatrix(int rows, int columns, int cardinality) {
+        super(rows, columns);
+        this.cardinality = cardinality;
+    }
+
     /**
      * Creates a zero {@link SparseMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -132,17 +143,6 @@ public abstract class SparseMatrix extends Matrix {
      */
     public static SparseMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.SPARSE);
-    }
-
-    protected int cardinality;
-
-    public SparseMatrix(int rows, int columns) {
-        this(rows, columns, 0);
-    }
-
-    public SparseMatrix(int rows, int columns, int cardinality) {
-        super(rows, columns);
-        this.cardinality = cardinality;
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
@@ -36,6 +36,21 @@ public class Basic1DMatrix extends DenseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x00;
 
+    private double self[];
+
+    public Basic1DMatrix() {
+        this(0, 0);
+    }
+
+    public Basic1DMatrix(int rows, int columns) {
+        this(rows, columns, new double[rows * columns]);
+    }
+
+    public Basic1DMatrix(int rows, int columns, double array[]) {
+        super(rows, columns);
+        this.self = array;
+    }
+
     /**
      * Creates a zero {@link Basic1DMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -219,21 +234,6 @@ public class Basic1DMatrix extends DenseMatrix {
      */
     public static Basic1DMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.BASIC_1D);
-    }
-
-    private double[] self;
-
-    public Basic1DMatrix() {
-        this(0, 0);
-    }
-
-    public Basic1DMatrix(int rows, int columns) {
-        this(rows, columns, new double[rows * columns]);
-    }
-
-    public Basic1DMatrix(int rows, int columns, double[] array) {
-        super(rows, columns);
-        this.self = array;
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
@@ -36,6 +36,21 @@ public class Basic2DMatrix extends DenseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x10;
 
+    private double self[][];
+
+    public Basic2DMatrix() {
+        this(0, 0);
+    }
+
+    public Basic2DMatrix(int rows, int columns) {
+        this(new double[rows][columns]);
+    }
+
+    public Basic2DMatrix(double array[][]) {
+        super(array.length, array.length == 0 ? 0: array[0].length);
+        this.self = array;
+    }
+
     /**
      * Creates a zero {@link Basic2DMatrix} of the given shape:
      * {@code rows} x {@code columns}.
@@ -221,21 +236,6 @@ public class Basic2DMatrix extends DenseMatrix {
      */
     public static Basic2DMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.BASIC_2D);
-    }
-
-    private double[][] self;
-
-    public Basic2DMatrix() {
-        this(0, 0);
-    }
-
-    public Basic2DMatrix(int rows, int columns) {
-        this(new double[rows][columns]);
-    }
-
-    public Basic2DMatrix(double[][] array) {
-        super(array.length, array.length == 0 ? 0: array[0].length);
-        this.self = array;
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -48,6 +48,38 @@ import org.la4j.vector.sparse.CompressedVector;
 public class CCSMatrix extends ColumnMajorSparseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x30;
+    private static final int MINIMUM_SIZE = 32;
+
+    private double values[];
+    private int rowIndices[];
+    private int columnPointers[];
+
+    public CCSMatrix() {
+        this(0, 0);
+    }
+
+    public CCSMatrix(int rows, int columns) {
+        this (rows, columns, 0);
+    }
+
+    public CCSMatrix(int rows, int columns, int capacity) {
+        super(rows, columns);
+        ensureCardinalityIsCorrect(rows, columns, capacity);
+
+        int alignedSize = align(capacity);
+        this.values = new double[alignedSize];
+        this.rowIndices = new int[alignedSize];
+        this.columnPointers = new int[columns + 1];
+    }
+
+    public CCSMatrix(int rows, int columns, int cardinality, double values[], int rowIndices[], int columnPointers[]) {
+        super(rows, columns, cardinality);
+        ensureCardinalityIsCorrect(rows, columns, cardinality);
+
+        this.values = values;
+        this.rowIndices = rowIndices;
+        this.columnPointers = columnPointers;
+    }
 
     /**
      * Creates a zero {@link CCSMatrix} of the given shape:
@@ -309,39 +341,6 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
      */
     public static CCSMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.CCS);
-    }
-
-    private static final int MINIMUM_SIZE = 32;
-
-    private double[] values;
-    private int[] rowIndices;
-    private int[] columnPointers;
-
-    public CCSMatrix() {
-        this(0, 0);
-    }
-
-    public CCSMatrix(int rows, int columns) {
-        this (rows, columns, 0);
-    }
-
-    public CCSMatrix(int rows, int columns, int capacity) {
-        super(rows, columns);
-        ensureCardinalityIsCorrect(rows, columns, capacity);
-
-        int alignedSize = align(capacity);
-        this.values = new double[alignedSize];
-        this.rowIndices = new int[alignedSize];
-        this.columnPointers = new int[columns + 1];
-    }
-
-    public CCSMatrix(int rows, int columns, int cardinality, double[] values, int[] rowIndices, int[] columnPointers) {
-        super(rows, columns, cardinality);
-        ensureCardinalityIsCorrect(rows, columns, cardinality);
-
-        this.values = values;
-        this.rowIndices = rowIndices;
-        this.columnPointers = columnPointers;
     }
 
     @Override

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -49,6 +49,38 @@ import org.la4j.vector.sparse.CompressedVector;
 public class CRSMatrix extends RowMajorSparseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x20;
+    private static final int MINIMUM_SIZE = 32;
+
+    private double values[];
+    private int columnIndices[];
+    private int rowPointers[];
+
+    public CRSMatrix() {
+        this(0, 0);
+    }
+
+    public CRSMatrix(int rows, int columns) {
+        this(rows, columns, 0);
+    }
+
+    public CRSMatrix(int rows, int columns, int capacity) {
+        super(rows, columns);
+        ensureCardinalityIsCorrect(rows, columns, capacity);
+
+        int alignedSize = align(capacity);
+        this.values = new double[alignedSize];
+        this.columnIndices = new int[alignedSize];
+        this.rowPointers = new int[rows + 1];
+    }
+
+    public CRSMatrix(int rows, int columns, int cardinality, double values[], int columnIndices[], int rowPointers[]) {
+        super(rows, columns, cardinality);
+        ensureCardinalityIsCorrect(rows, columns, cardinality);
+
+        this.values = values;
+        this.columnIndices = columnIndices;
+        this.rowPointers = rowPointers;
+    }
 
     /**
      * Creates a zero {@link CRSMatrix} of the given shape:
@@ -310,39 +342,6 @@ public class CRSMatrix extends RowMajorSparseMatrix {
      */
     public static CRSMatrix fromMatrixMarket(String mm) {
         return Matrix.fromMatrixMarket(mm).to(Matrices.CRS);
-    }
-
-    private static final int MINIMUM_SIZE = 32;
-
-    private double[] values;
-    private int[] columnIndices;
-    private int[] rowPointers;
-
-    public CRSMatrix() {
-        this(0, 0);
-    }
-
-    public CRSMatrix(int rows, int columns) {
-        this(rows, columns, 0);
-    }
-
-    public CRSMatrix(int rows, int columns, int capacity) {
-        super(rows, columns);
-        ensureCardinalityIsCorrect(rows, columns, capacity);
-
-        int alignedSize = align(capacity);
-        this.values = new double[alignedSize];
-        this.columnIndices = new int[alignedSize];
-        this.rowPointers = new int[rows + 1];
-    }
-
-    public CRSMatrix(int rows, int columns, int cardinality, double[] values, int[] columnIndices, int[] rowPointers) {
-        super(rows, columns, cardinality);
-        ensureCardinalityIsCorrect(rows, columns, cardinality);
-
-        this.values = values;
-        this.columnIndices = columnIndices;
-        this.rowPointers = rowPointers;
     }
 
     @Override

--- a/src/main/java/org/la4j/vector/DenseVector.java
+++ b/src/main/java/org/la4j/vector/DenseVector.java
@@ -50,6 +50,10 @@ import java.util.Random;
  */
 public abstract class DenseVector extends Vector {
 
+    public DenseVector(int length) {
+        super(length);
+    }
+
     /**
      * Creates a zero {@link DenseVector} of the given {@code length}.
      */
@@ -156,10 +160,6 @@ public abstract class DenseVector extends Vector {
      * @return an array representation of this vector
      */
     public abstract double[] toArray();
-
-    public DenseVector(int length) {
-        super(length);
-    }
 
     @Override
     public Matrix toRowMatrix() {

--- a/src/main/java/org/la4j/vector/SparseVector.java
+++ b/src/main/java/org/la4j/vector/SparseVector.java
@@ -55,6 +55,17 @@ import org.la4j.vector.sparse.CompressedVector;
  */
 public abstract class SparseVector extends Vector {
 
+    protected int cardinality;
+
+    public SparseVector(int length) {
+        this(length, 0);
+    }
+
+    public SparseVector(int length, int cardinality) {
+        super(length);
+        this.cardinality = cardinality;
+    }
+
     /**
      * Creates a zero {@link SparseVector} of the given {@code length}.
      */
@@ -128,17 +139,6 @@ public abstract class SparseVector extends Vector {
      */
     public static SparseVector fromMap(Map<Integer, ? extends Number> map, int length) {
         return CompressedVector.fromMap(map, length);
-    }
-
-    protected int cardinality;
-
-    public SparseVector(int length) {
-        this(length, 0);
-    }
-
-    public SparseVector(int length, int cardinality) {
-        super(length);
-        this.cardinality = cardinality;
     }
 
     /**

--- a/src/main/java/org/la4j/vector/dense/BasicVector.java
+++ b/src/main/java/org/la4j/vector/dense/BasicVector.java
@@ -51,6 +51,21 @@ public class BasicVector extends DenseVector {
 
     private static final byte VECTOR_TAG = (byte) 0x00;
 
+    private double self[];
+
+    public BasicVector() {
+        this(0);
+    }
+
+    public BasicVector(int length) {
+        this(new double[length]);
+    }
+
+    public BasicVector(double array[]) {
+        super(array.length);
+        this.self = array;
+    }
+
     /**
      * Creates a zero {@link BasicVector} of the given {@code length}.
      */
@@ -170,21 +185,6 @@ public class BasicVector extends DenseVector {
      */
     public static BasicVector fromMap(Map<Integer, ? extends Number> map, int length) {
         return Vector.fromMap(map, length).to(Vectors.BASIC);
-    }
-
-    private double[] self;
-
-    public BasicVector() {
-        this(0);
-    }
-
-    public BasicVector(int length) {
-        this(new double[length]);
-    }
-
-    public BasicVector(double[] array) {
-        super(array.length);
-        this.self = array;
     }
 
     @Override

--- a/src/main/java/org/la4j/vector/sparse/CompressedVector.java
+++ b/src/main/java/org/la4j/vector/sparse/CompressedVector.java
@@ -60,6 +60,30 @@ public class CompressedVector extends SparseVector {
 
     private static final int MINIMUM_SIZE = 32;
 
+    private double values[];
+    private int indices[];
+
+    public CompressedVector() {
+        this(0);
+    }
+
+    public CompressedVector(int length) {
+        this(length, 0);
+    }
+
+    public CompressedVector(int length, int capacity) {
+        super(length);
+        int alignedSize = align(length, capacity);
+        this.values = new double[alignedSize];
+        this.indices = new int[alignedSize];
+    }
+
+    public CompressedVector(int length, int cardinality, double values[], int indices[]) {
+        super(length, cardinality);
+        this.values = values;
+        this.indices = indices;
+    }
+
     /**
      * Creates a zero {@link CompressedVector} of the given {@code length}.
      */
@@ -200,30 +224,6 @@ public class CompressedVector extends SparseVector {
             i++;
         }
         return new CompressedVector(length, cardinality, values, indices);
-    }
-
-    private double[] values;
-    private int[] indices;
-
-    public CompressedVector() {
-        this(0);
-    }
-
-    public CompressedVector(int length) {
-        this(length, 0);
-    }
-
-    public CompressedVector(int length, int capacity) {
-        super(length);
-        int alignedSize = align(length, capacity);
-        this.values = new double[alignedSize];
-        this.indices = new int[alignedSize];
-    }
-
-    public CompressedVector(int length, int cardinality, double[] values, int[] indices) {
-        super(length, cardinality);
-        this.values = values;
-        this.indices = indices;
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava