### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the variable

### DIFF
--- a/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
@@ -36,7 +36,7 @@ public class Basic1DMatrix extends DenseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x00;
 
-    private double self[];
+    private double[] self;
 
     public Basic1DMatrix() {
         this(0, 0);
@@ -46,7 +46,7 @@ public class Basic1DMatrix extends DenseMatrix {
         this(rows, columns, new double[rows * columns]);
     }
 
-    public Basic1DMatrix(int rows, int columns, double array[]) {
+    public Basic1DMatrix(int rows, int columns, double[] array) {
         super(rows, columns);
         this.self = array;
     }

--- a/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
@@ -36,7 +36,7 @@ public class Basic2DMatrix extends DenseMatrix {
 
     private static final byte MATRIX_TAG = (byte) 0x10;
 
-    private double self[][];
+    private double[][] self;
 
     public Basic2DMatrix() {
         this(0, 0);
@@ -46,7 +46,7 @@ public class Basic2DMatrix extends DenseMatrix {
         this(new double[rows][columns]);
     }
 
-    public Basic2DMatrix(double array[][]) {
+    public Basic2DMatrix(double[][] array) {
         super(array.length, array.length == 0 ? 0: array[0].length);
         this.self = array;
     }

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -50,9 +50,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
     private static final byte MATRIX_TAG = (byte) 0x30;
     private static final int MINIMUM_SIZE = 32;
 
-    private double values[];
-    private int rowIndices[];
-    private int columnPointers[];
+    private double[] values;
+    private int[] rowIndices;
+    private int[] columnPointers;
 
     public CCSMatrix() {
         this(0, 0);
@@ -72,7 +72,7 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
         this.columnPointers = new int[columns + 1];
     }
 
-    public CCSMatrix(int rows, int columns, int cardinality, double values[], int rowIndices[], int columnPointers[]) {
+    public CCSMatrix(int rows, int columns, int cardinality, double[] values, int[] rowIndices, int[] columnPointers) {
         super(rows, columns, cardinality);
         ensureCardinalityIsCorrect(rows, columns, cardinality);
 

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -51,9 +51,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
     private static final byte MATRIX_TAG = (byte) 0x20;
     private static final int MINIMUM_SIZE = 32;
 
-    private double values[];
-    private int columnIndices[];
-    private int rowPointers[];
+    private double[] values;
+    private int[] columnIndices;
+    private int[] rowPointers;
 
     public CRSMatrix() {
         this(0, 0);
@@ -73,7 +73,7 @@ public class CRSMatrix extends RowMajorSparseMatrix {
         this.rowPointers = new int[rows + 1];
     }
 
-    public CRSMatrix(int rows, int columns, int cardinality, double values[], int columnIndices[], int rowPointers[]) {
+    public CRSMatrix(int rows, int columns, int cardinality, double[] values, int[] columnIndices, int[] rowPointers) {
         super(rows, columns, cardinality);
         ensureCardinalityIsCorrect(rows, columns, cardinality);
 

--- a/src/main/java/org/la4j/vector/dense/BasicVector.java
+++ b/src/main/java/org/la4j/vector/dense/BasicVector.java
@@ -51,7 +51,7 @@ public class BasicVector extends DenseVector {
 
     private static final byte VECTOR_TAG = (byte) 0x00;
 
-    private double self[];
+    private double[] self;
 
     public BasicVector() {
         this(0);
@@ -61,7 +61,7 @@ public class BasicVector extends DenseVector {
         this(new double[length]);
     }
 
-    public BasicVector(double array[]) {
+    public BasicVector(double[] array) {
         super(array.length);
         this.self = array;
     }

--- a/src/main/java/org/la4j/vector/sparse/CompressedVector.java
+++ b/src/main/java/org/la4j/vector/sparse/CompressedVector.java
@@ -60,8 +60,8 @@ public class CompressedVector extends SparseVector {
 
     private static final int MINIMUM_SIZE = 32;
 
-    private double values[];
-    private int indices[];
+    private double[] values;
+    private int[] indices;
 
     public CompressedVector() {
         this(0);
@@ -78,7 +78,7 @@ public class CompressedVector extends SparseVector {
         this.indices = new int[alignedSize];
     }
 
-    public CompressedVector(int length, int cardinality, double values[], int indices[]) {
+    public CompressedVector(int length, int cardinality, double[] values, int[] indices) {
         super(length, cardinality);
         this.values = values;
         this.indices = indices;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava