### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/la4j/LinearAlgebra.java
+++ b/src/main/java/org/la4j/LinearAlgebra.java
@@ -94,6 +94,8 @@ public final class LinearAlgebra {
      */
     public static final int ROUND_FACTOR;
 
+    private LinearAlgebra() {}
+
     // Determine the machine epsilon
     // Tolerance is 10e1
     static {

--- a/src/main/java/org/la4j/Matrices.java
+++ b/src/main/java/org/la4j/Matrices.java
@@ -51,6 +51,8 @@ public final class Matrices {
      */
     public static final int ROUND_FACTOR = LinearAlgebra.ROUND_FACTOR;
 
+    private Matrices() {}
+
     /**
      * Checks whether the matrix is a
      * <a href="http://mathworld.wolfram.com/DiagonalMatrix.html">diagonal

--- a/src/main/java/org/la4j/Vectors.java
+++ b/src/main/java/org/la4j/Vectors.java
@@ -126,6 +126,8 @@ public final class Vectors {
         }
     };
 
+    private Vectors() {}
+
     /**
      * Creates a const function that evaluates it's argument to given {@code value}.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava