### PR TITLE
squid:S1659 - Multiple variables should not be declared on the same line

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -189,7 +189,8 @@ public abstract class Matrix implements Iterable<Double> {
     public static Matrix fromCSV(String csv) {
         StringTokenizer lines = new StringTokenizer(csv, "\n");
         Matrix result = DenseMatrix.zero(10, 10);
-        int rows = 0, columns = 0;
+        int rows = 0;
+        int columns = 0;
 
         while (lines.hasMoreTokens()) {
             if (result.rows() == rows) {

--- a/src/main/java/org/la4j/decomposition/EigenDecompositor.java
+++ b/src/main/java/org/la4j/decomposition/EigenDecompositor.java
@@ -94,7 +94,8 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
         double n = Matrices.EPS;
         double nn = r.fold(normAccumulator);
 
-        int kk = 0, ll = 0;
+        int kk = 0;
+        int ll = 0;
 
         while (Math.abs(n - nn) > Matrices.EPS) {
 
@@ -183,7 +184,8 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
         u.set(kk, ll, 0.0);
         u.set(ll, kk, 0.0);
 
-        double alpha = 0.0, beta = 0.0;
+        double alpha = 0.0;
+        double beta = 0.0;
 
         if (Math.abs(matrix.get(k, k) - matrix.get(l, l)) < Matrices.EPS) {
             alpha = beta = Math.sqrt(0.5);
@@ -353,7 +355,15 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
         int high = nn - 1;
         double eps = Math.pow(2.0, -52.0);
         double exshift = 0.0;
-        double p = 0, q = 0, r = 0, s = 0, z = 0, t, w, x, y;
+        double p = 0;
+        double q = 0;
+        double r = 0;
+        double s = 0;
+        double z = 0;
+        double t;
+        double w;
+        double x;
+        double y;
 
         // Store roots isolated by balanc and compute matrix norm
 
@@ -709,7 +719,10 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
                 H.set(n, n - 1, 0.0);
                 H.set(n, n, 1.0);
                 for (int i = n - 2; i >= 0; i--) {
-                    double ra, sa, vr, vi;
+                    double ra;
+                    double sa;
+                    double vr;
+                    double vi;
                     ra = 0.0;
                     sa = 0.0;
                     for (int j = l; j <= n; j++) {
@@ -804,8 +817,10 @@ public class EigenDecompositor extends AbstractDecompositor implements MatrixDec
 
 
    private double[] cdiv(double xr, double xi, double yr, double yi) {
-        double cdivr, cdivi;
-        double r, d;
+        double cdivr;
+        double cdivi;
+        double r;
+        double d;
         if (Math.abs(yr) > Math.abs(yi)) {
             r = yi / yr;
             d = yr + r * yi;

--- a/src/main/java/org/la4j/decomposition/SingularValueDecompositor.java
+++ b/src/main/java/org/la4j/decomposition/SingularValueDecompositor.java
@@ -275,7 +275,8 @@ public class SingularValueDecompositor extends AbstractDecompositor implements M
 
         while (p > 0) {
 
-            int k, kase;
+            int k;
+            int kase;
 
             for (k = p - 2; k >= -1; k--) {
                 if (k == -1)

--- a/src/main/java/org/la4j/iterator/CursorIterator.java
+++ b/src/main/java/org/la4j/iterator/CursorIterator.java
@@ -142,8 +142,10 @@ abstract class CursorIterator implements Iterator<Double> {
         final CursorIterator these = this;
         return new CursorIterator() {
             private boolean hasNext;
-            private double prevValue, currValue;
-            private int prevCursor, currCursor;
+            private double prevValue;
+            private double currValue;
+            private int prevCursor;
+            private int currCursor;
 
             {
                 doNext();

--- a/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic1DMatrix.java
@@ -165,7 +165,8 @@ public class Basic1DMatrix extends DenseMatrix {
             throw new IllegalArgumentException("Sides of blocks are incompatible!");
         }
 
-        int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
+        int rows = a.rows() + c.rows();
+        int columns = a.columns() + b.columns();
         double[] array = new double[rows * columns];
 
         for (int i = 0; i < rows; i++) {

--- a/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
+++ b/src/main/java/org/la4j/matrix/dense/Basic2DMatrix.java
@@ -166,7 +166,8 @@ public class Basic2DMatrix extends DenseMatrix {
             throw new IllegalArgumentException("Sides of blocks are incompatible!");
         }
 
-        int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
+        int rows = a.rows() + c.rows();
+        int columns = a.columns() + b.columns();
         double[][] array = new double[rows][columns];
 
         for (int i = 0; i < rows; i++) {

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -247,7 +247,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
             throw new IllegalArgumentException("Sides of blocks are incompatible!");
         }
 
-        int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
+        int rows = a.rows() + c.rows();
+        int columns = a.columns() + b.columns();
         ArrayList<Double> values = new ArrayList<Double>();
         ArrayList<Integer> rowIndices = new ArrayList<Integer>();
         int[] columnPointers = new int[rows + 1];
@@ -456,7 +457,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
         int $cardinality = 0;
 
-        int k = 0, j = 0;
+        int k = 0;
+        int j = 0;
         while (k < cardinality && j < columns) {
 
             $columnPointers[j] = $cardinality;
@@ -480,7 +482,8 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
     @Override
     public void eachNonZero(MatrixProcedure procedure) {
-        int k = 0, j = 0;
+        int k = 0;
+        int j = 0;
         while (k < cardinality) {
             for (int i = columnPointers[j]; i < columnPointers[j + 1]; i++, k++) {
                 procedure.apply(rowIndices[i], j, values[i]);

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -248,7 +248,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
             throw new IllegalArgumentException("Sides of blocks are incompatible!");
         }
 
-        int rows = a.rows() + c.rows(), columns = a.columns() + b.columns();
+        int rows = a.rows() + c.rows();
+        int columns = a.columns() + b.columns();
         ArrayList<Double> values = new ArrayList<Double>();
         ArrayList<Integer> columnIndices = new ArrayList<Integer>();
         int[] rowPointers = new int[rows + 1];
@@ -456,7 +457,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
         int $cardinality = 0;
 
-        int k = 0, i = 0;
+        int k = 0;
+        int i = 0;
         while (k < cardinality && i < rows) {
 
             $rowPointers[i] = $cardinality;
@@ -480,7 +482,8 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
     @Override
     public void eachNonZero(MatrixProcedure procedure) {
-        int k = 0, i = 0;
+        int k = 0;
+        int i = 0;
         while (k < cardinality) {
             for (int j = rowPointers[i]; j < rowPointers[i + 1]; j++, k++) {
                 procedure.apply(i, columnIndices[j], values[j]);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1659 - Multiple variables should not be declared on the same line.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1659
Please let me know if you have any questions.
George Kankava