### PR TITLE
squid:S2272 - 'Iterator.next()' methods should throw 'NoSuchElementException'

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -54,6 +54,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.StringTokenizer;
 
@@ -1900,6 +1901,10 @@ public abstract class Matrix implements Iterable<Double> {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
                 i++;
                 return get();
             }
@@ -1943,6 +1948,9 @@ public abstract class Matrix implements Iterable<Double> {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return get();
             }
@@ -1981,6 +1989,9 @@ public abstract class Matrix implements Iterable<Double> {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 j++;
                 return get();
             }
@@ -2018,6 +2029,9 @@ public abstract class Matrix implements Iterable<Double> {
 
              @Override
              public Double next() {
+                 if(!hasNext()) {
+                     throw new NoSuchElementException();
+                 }
                  i++;
                  return get();
              }

--- a/src/main/java/org/la4j/Vector.java
+++ b/src/main/java/org/la4j/Vector.java
@@ -27,10 +27,7 @@ package org.la4j;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Random;
-import java.util.StringTokenizer;
+import java.util.*;
 
 import org.la4j.iterator.VectorIterator;
 import org.la4j.vector.VectorFactory;
@@ -905,6 +902,9 @@ public abstract class Vector implements Iterable<Double> {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return get();
             }

--- a/src/main/java/org/la4j/iterator/CursorIterator.java
+++ b/src/main/java/org/la4j/iterator/CursorIterator.java
@@ -21,10 +21,7 @@
 
 package org.la4j.iterator;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Iterator;
+import java.util.*;
 
 abstract class CursorIterator implements Iterator<Double> {
 
@@ -198,6 +195,9 @@ abstract class CursorIterator implements Iterator<Double> {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 doNext();
                 return get();
             }

--- a/src/main/java/org/la4j/matrix/SparseMatrix.java
+++ b/src/main/java/org/la4j/matrix/SparseMatrix.java
@@ -38,6 +38,7 @@ import org.la4j.vector.functor.VectorProcedure;
 import org.la4j.vector.SparseVector;
 
 import java.text.NumberFormat;
+import java.util.NoSuchElementException;
 import java.util.Random;
 
 public abstract class SparseMatrix extends Matrix {
@@ -452,6 +453,9 @@ public abstract class SparseMatrix extends Matrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return get();
             }
@@ -503,6 +507,9 @@ public abstract class SparseMatrix extends Matrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return get();
             }
@@ -545,6 +552,9 @@ public abstract class SparseMatrix extends Matrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 j++;
                 return get();
             }
@@ -587,6 +597,9 @@ public abstract class SparseMatrix extends Matrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return get();
             }

--- a/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CCSMatrix.java
@@ -26,10 +26,8 @@
 package org.la4j.matrix.sparse;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Random;
+import java.util.*;
+
 import org.la4j.iterator.ColumnMajorMatrixIterator;
 import org.la4j.iterator.VectorIterator;
 import org.la4j.Matrices;
@@ -776,6 +774,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
             @Override
             public Integer next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 j++;
                 return j;
             }
@@ -832,6 +833,10 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
                 if (currentNonZero) {
                     k++;
                 }
@@ -888,6 +893,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 currentIsRemoved = false;
                 k++;
                 while (columnPointers[j + 1] == k) {
@@ -937,6 +945,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 currentIsRemoved = false;
                 return values[++k];
             }
@@ -983,6 +994,9 @@ public class CCSMatrix extends ColumnMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 if (k < columnPointers[jj + 1] && rowIndices[k] == i - 1) {
                     k++;

--- a/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
+++ b/src/main/java/org/la4j/matrix/sparse/CRSMatrix.java
@@ -26,10 +26,7 @@
 package org.la4j.matrix.sparse;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Random;
+import java.util.*;
 
 import org.la4j.iterator.RowMajorMatrixIterator;
 import org.la4j.iterator.VectorIterator;
@@ -776,6 +773,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
             @Override
             public Integer next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 i++;
                 return i;
             }
@@ -832,6 +832,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 if (currentNonZero) {
                     k++;
                 }
@@ -888,6 +891,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 currentIsRemoved = false;
                 k++;
                 while (rowPointers[i + 1] == k) {
@@ -937,6 +943,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 currentIsRemoved = false;
                 return values[++k];
             }
@@ -983,6 +992,9 @@ public class CRSMatrix extends RowMajorSparseMatrix {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 j++;
                 if (k < rowPointers[ii + 1] && columnIndices[k] == j - 1) {
                     k++;

--- a/src/main/java/org/la4j/vector/sparse/CompressedVector.java
+++ b/src/main/java/org/la4j/vector/sparse/CompressedVector.java
@@ -24,10 +24,7 @@
 package org.la4j.vector.sparse;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import org.la4j.Vectors;
 import org.la4j.iterator.VectorIterator;
@@ -567,6 +564,9 @@ public class CompressedVector extends SparseVector {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 currentIsRemoved = false;
                 return values[++k];
             }
@@ -612,6 +612,9 @@ public class CompressedVector extends SparseVector {
 
             @Override
             public Double next() {
+                if(!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 if (currentNonZero) {
                     k++;
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2272 - 'Iterator.next()' methods should throw 'NoSuchElementException'.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2272
Please let me know if you have any questions.
George Kankava