### PR TITLE
squid:S2111 - BigDecimal(double) should not be used

### DIFF
--- a/src/main/java/org/la4j/Matrices.java
+++ b/src/main/java/org/la4j/Matrices.java
@@ -564,17 +564,17 @@ public final class Matrices {
      */
     public static MatrixAccumulator mkEuclideanNormAccumulator() {
         return new MatrixAccumulator() {
-            private BigDecimal result = new BigDecimal(0.0);
+            private BigDecimal result = BigDecimal.valueOf(0.0);
 
             @Override
             public void update(int i, int j, double value) {
-                result = result.add(new BigDecimal(value * value));
+                result = result.add(BigDecimal.valueOf(value * value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Matrices.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(0.0);
+                result = BigDecimal.valueOf(0.0);
                 return Math.sqrt(value);
             }
         };
@@ -639,17 +639,17 @@ public final class Matrices {
      */
     public static MatrixAccumulator asSumAccumulator(final double neutral) {
         return new MatrixAccumulator() {
-            private BigDecimal result = new BigDecimal(neutral);
+            private BigDecimal result = BigDecimal.valueOf(neutral);
 
             @Override
             public void update(int i, int j, double value) {
-                result = result.add(new BigDecimal(value));
+                result = result.add(BigDecimal.valueOf(value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Matrices.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(neutral);
+                result = BigDecimal.valueOf(neutral);
                 return value;
             }
         };
@@ -664,17 +664,17 @@ public final class Matrices {
      */
     public static MatrixAccumulator asProductAccumulator(final double neutral) {
         return new MatrixAccumulator() {
-            private BigDecimal result = new BigDecimal(neutral);
+            private BigDecimal result = BigDecimal.valueOf(neutral);
 
             @Override
             public void update(int i, int j, double value) {
-                result = result.multiply(new BigDecimal(value));
+                result = result.multiply(BigDecimal.valueOf(value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Matrices.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(neutral);
+                result = BigDecimal.valueOf(neutral);
                 return value;
             }
         };

--- a/src/main/java/org/la4j/Vectors.java
+++ b/src/main/java/org/la4j/Vectors.java
@@ -233,17 +233,17 @@ public final class Vectors {
      */
     public static VectorAccumulator asSumAccumulator(final double neutral) {
         return new VectorAccumulator() {
-            private BigDecimal result = new BigDecimal(neutral);
+            private BigDecimal result = BigDecimal.valueOf(neutral);
 
             @Override
             public void update(int i, double value) {
-                result = result.add(new BigDecimal(value));
+                result = result.add(BigDecimal.valueOf(value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Vectors.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(neutral);
+                result = BigDecimal.valueOf(neutral);
                 return value;
             }
         };
@@ -258,17 +258,17 @@ public final class Vectors {
      */
     public static VectorAccumulator asProductAccumulator(final double neutral) {
         return new VectorAccumulator() {
-            private BigDecimal result = new BigDecimal(neutral);
+            private BigDecimal result = BigDecimal.valueOf(neutral);
 
             @Override
             public void update(int i, double value) {
-                result = result.multiply(new BigDecimal(value));
+                result = result.multiply(BigDecimal.valueOf(value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Vectors.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(neutral);
+                result = BigDecimal.valueOf(neutral);
                 return value;
             }
         };
@@ -328,17 +328,17 @@ public final class Vectors {
      */
     public static VectorAccumulator mkEuclideanNormAccumulator() {
         return new VectorAccumulator() {
-            private BigDecimal result = new BigDecimal(0.0);
+            private BigDecimal result = BigDecimal.valueOf(0.0);
 
             @Override
             public void update(int i, double value) {
-                result = result.add(new BigDecimal(value * value));
+                result = result.add(BigDecimal.valueOf(value * value));
             }
 
             @Override
             public double accumulate() {
                 double value = result.setScale(Vectors.ROUND_FACTOR, RoundingMode.CEILING).doubleValue();
-                result = new BigDecimal(0.0);
+                result = BigDecimal.valueOf(0.0);
                 return Math.sqrt(value);
             }
         };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2111 - "BigDecimal(double)" should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2111
Please let me know if you have any questions.
George Kankava