### PR TITLE
squid:S2130 - Parsing should be used to convert 'Strings' to primitives

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -205,7 +205,7 @@ public abstract class Matrix implements Iterable<Double> {
                     result = result.copyOfColumns((j * 3) / 2 + 1);
                 }
 
-                double x = Double.valueOf(elements.nextToken());
+                double x = Double.parseDouble(elements.nextToken());
                 result.set(rows, j++, x);
             }
 
@@ -263,9 +263,9 @@ public abstract class Matrix implements Iterable<Double> {
         if ("coordinate".equals(format)) {
             StringTokenizer lines = new StringTokenizer(nextToken);
 
-            int rows = Integer.valueOf(lines.nextToken());
-            int columns = Integer.valueOf(lines.nextToken());
-            int cardinality = Integer.valueOf(lines.nextToken());
+            int rows = Integer.parseInt(lines.nextToken());
+            int columns = Integer.parseInt(lines.nextToken());
+            int cardinality = Integer.parseInt(lines.nextToken());
 
             Matrix result = "row-major".equals(majority) ?
                     RowMajorSparseMatrix.zero(rows, columns, cardinality) :

--- a/src/main/java/org/la4j/Vector.java
+++ b/src/main/java/org/la4j/Vector.java
@@ -128,7 +128,7 @@ public abstract class Vector implements Iterable<Double> {
                 result = result.copyOfLength((i * 3) / 2 + 1);
             }
 
-            double x = Double.valueOf(tokenizer.nextToken());
+            double x = Double.parseDouble(tokenizer.nextToken());
             result.set(i++, x);
         }
 
@@ -165,14 +165,14 @@ public abstract class Vector implements Iterable<Double> {
             throw new IllegalArgumentException("Unknown field type: " + field + ".");
         }
 
-        int length = Integer.valueOf(body.nextToken());
+        int length = Integer.parseInt(body.nextToken());
         if ("coordinate".equals(format)) {
-            int cardinality = Integer.valueOf(body.nextToken());
+            int cardinality = Integer.parseInt(body.nextToken());
             Vector result = SparseVector.zero(length, cardinality);
 
             for (int k = 0; k < cardinality; k++) {
-                int i = Integer.valueOf(body.nextToken());
-                double x = Double.valueOf(body.nextToken());
+                int i = Integer.parseInt(body.nextToken());
+                double x = Double.parseDouble(body.nextToken());
                 result.set(i - 1, x);
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2130 - Parsing should be used to convert 'Strings' to primitives.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2130
Please let me know if you have any questions.
George Kankava