### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/la4j/LinearAlgebra.java
+++ b/src/main/java/org/la4j/LinearAlgebra.java
@@ -94,81 +94,6 @@ public final class LinearAlgebra {
      */
     public static final int ROUND_FACTOR;
 
-    private LinearAlgebra() {}
-
-    // Determine the machine epsilon
-    // Tolerance is 10e1
-    static {
-        int roundFactor = 0;
-        double eps = 1.0;
-        while (1 + eps > 1) {
-            eps = eps / 2;
-            roundFactor++;
-        }
-        EPS = eps * 10e1;
-        ROUND_FACTOR = roundFactor - 1;
-    }
-
-    public static enum SolverFactory {
-        GAUSSIAN {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new GaussianSolver(matrix);
-            }
-        },
-        JACOBI {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new JacobiSolver(matrix);
-            }
-        },
-        SEIDEL {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new SeidelSolver(matrix);
-            }
-        },
-        FORWARD_BACK_SUBSTITUTION {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new ForwardBackSubstitutionSolver(matrix);
-            }
-        },
-        LEAST_SQUARES {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new LeastSquaresSolver(matrix);
-            }
-        },
-        SQUARE_ROOT {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new SquareRootSolver(matrix);
-            }
-        },
-        SWEEP {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                return new SweepSolver(matrix);
-            }
-        },
-        SMART {
-            @Override
-            public LinearSystemSolver create(Matrix matrix) {
-                // TODO: We can do it smarter in future
-                if (matrix.rows() == matrix.columns()) {
-                    return new ForwardBackSubstitutionSolver(matrix);
-                } else if (matrix.rows() > matrix.columns()) {
-                    return new LeastSquaresSolver(matrix);
-                }
-
-                throw new IllegalArgumentException("Underdetermined system of linear equations can not be solved.");
-            }
-        };
-
-        public abstract LinearSystemSolver create(Matrix matrix);
-    }
-
     /**
      * References to the Gaussian solver factory.
      */
@@ -209,29 +134,6 @@ public final class LinearAlgebra {
      */
     public static final SolverFactory SWEEP = SolverFactory.SWEEP;
 
-    public static enum InverterFactory {
-        GAUSS_JORDAN {
-            @Override
-            public MatrixInverter create(Matrix matrix) {
-                return new GaussJordanInverter(matrix);
-            }
-        },
-        NO_PIVOT_GAUSS {
-            @Override
-            public MatrixInverter create(Matrix matrix) {
-                return new NoPivotGaussInverter(matrix);
-            }
-        },
-        SMART {
-            @Override
-            public MatrixInverter create(Matrix matrix) {
-                return new GaussJordanInverter(matrix);
-            }
-        };
-
-        public abstract MatrixInverter create(Matrix matrix);
-    }
-
     /**
      * Reference to an inverter factory solving n linear systems.
      */
@@ -239,64 +141,17 @@ public final class LinearAlgebra {
 
     /**
      * Reference to the Gauss elimination method-based inverter factory.
-     * 
+     *
      * Note: this version of the Gauss elimination method does not use a
      * pivot and does not swap either columns or rows. As a result, it will fail
      * if there is a zero on the diagonal.
      */
     public static final InverterFactory NO_PIVOT_GAUSS = InverterFactory.NO_PIVOT_GAUSS;
-    
+
     /**
      * Reference to the Smart inverter factory.
      */
     public static final InverterFactory INVERTER = InverterFactory.SMART;
-
-    public static enum DecompositorFactory {
-          CHOLESKY {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new CholeskyDecompositor(matrix);
-              }
-          },
-          EIGEN {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new EigenDecompositor(matrix);
-              }
-          },
-          RAW_LU {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new RawLUDecompositor(matrix);
-              }
-          },
-          LU {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new LUDecompositor(matrix);
-              }
-          },
-          RAW_QR {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new RawQRDecompositor(matrix);
-              }
-          },
-          QR {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new QRDecompositor(matrix);
-              }
-          },
-          SVD {
-              @Override
-              public MatrixDecompositor create(Matrix matrix) {
-                  return new SingularValueDecompositor(matrix);
-              }
-          };
-
-        public abstract MatrixDecompositor create(Matrix matrix);
-    }
 
     /**
      * Reference to Cholesky decompositor factory.
@@ -374,4 +229,149 @@ public final class LinearAlgebra {
 
     public final static MatrixMatrixOperation<Matrix> OO_PLACE_MATRICES_MULTIPLICATION =
         new OoPlaceMatricesMultiplication();
+
+    private LinearAlgebra() {}
+
+    // Determine the machine epsilon
+    // Tolerance is 10e1
+    static {
+        int roundFactor = 0;
+        double eps = 1.0;
+        while (1 + eps > 1) {
+            eps = eps / 2;
+            roundFactor++;
+        }
+        EPS = eps * 10e1;
+        ROUND_FACTOR = roundFactor - 1;
+    }
+
+    public static enum SolverFactory {
+        GAUSSIAN {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new GaussianSolver(matrix);
+            }
+        },
+        JACOBI {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new JacobiSolver(matrix);
+            }
+        },
+        SEIDEL {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new SeidelSolver(matrix);
+            }
+        },
+        FORWARD_BACK_SUBSTITUTION {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new ForwardBackSubstitutionSolver(matrix);
+            }
+        },
+        LEAST_SQUARES {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new LeastSquaresSolver(matrix);
+            }
+        },
+        SQUARE_ROOT {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new SquareRootSolver(matrix);
+            }
+        },
+        SWEEP {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                return new SweepSolver(matrix);
+            }
+        },
+        SMART {
+            @Override
+            public LinearSystemSolver create(Matrix matrix) {
+                // TODO: We can do it smarter in future
+                if (matrix.rows() == matrix.columns()) {
+                    return new ForwardBackSubstitutionSolver(matrix);
+                } else if (matrix.rows() > matrix.columns()) {
+                    return new LeastSquaresSolver(matrix);
+                }
+
+                throw new IllegalArgumentException("Underdetermined system of linear equations can not be solved.");
+            }
+        };
+
+        public abstract LinearSystemSolver create(Matrix matrix);
+    }
+
+    public static enum InverterFactory {
+        GAUSS_JORDAN {
+            @Override
+            public MatrixInverter create(Matrix matrix) {
+                return new GaussJordanInverter(matrix);
+            }
+        },
+        NO_PIVOT_GAUSS {
+            @Override
+            public MatrixInverter create(Matrix matrix) {
+                return new NoPivotGaussInverter(matrix);
+            }
+        },
+        SMART {
+            @Override
+            public MatrixInverter create(Matrix matrix) {
+                return new GaussJordanInverter(matrix);
+            }
+        };
+
+        public abstract MatrixInverter create(Matrix matrix);
+    }
+
+    public static enum DecompositorFactory {
+        CHOLESKY {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new CholeskyDecompositor(matrix);
+            }
+        },
+        EIGEN {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new EigenDecompositor(matrix);
+            }
+        },
+        RAW_LU {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new RawLUDecompositor(matrix);
+            }
+        },
+        LU {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new LUDecompositor(matrix);
+            }
+        },
+        RAW_QR {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new RawQRDecompositor(matrix);
+            }
+        },
+        QR {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new QRDecompositor(matrix);
+            }
+        },
+        SVD {
+            @Override
+            public MatrixDecompositor create(Matrix matrix) {
+                return new SingularValueDecompositor(matrix);
+            }
+        };
+
+        public abstract MatrixDecompositor create(Matrix matrix);
+    }
 }

--- a/src/main/java/org/la4j/Matrices.java
+++ b/src/main/java/org/la4j/Matrices.java
@@ -51,8 +51,6 @@ public final class Matrices {
      */
     public static final int ROUND_FACTOR = LinearAlgebra.ROUND_FACTOR;
 
-    private Matrices() {}
-
     /**
      * Checks whether the matrix is a
      * <a href="http://mathworld.wolfram.com/DiagonalMatrix.html">diagonal
@@ -220,6 +218,127 @@ public final class Matrices {
         }
     };
 
+    /**
+     * Checks whether the matrix is a
+     * <a href="http://mathworld.wolfram.com/SymmetricMatrix.html">symmetric
+     * matrix</a>.
+     */
+    public static final AdvancedMatrixPredicate SYMMETRIC_MATRIX =
+            new SymmetricMatrixPredicate();
+
+    /**
+     * Checks whether the matrix is a
+     * <a href="http://en.wikipedia.org/wiki/Diagonally_dominant_matrix">diagonally dominant matrix</a>.
+     */
+    public static final AdvancedMatrixPredicate DIAGONALLY_DOMINANT_MATRIX =
+            new DiagonallyDominantPredicate();
+
+    /**
+     * Checks whether the matrix is positive definite.
+     */
+    public static final AdvancedMatrixPredicate POSITIVE_DEFINITE_MATRIX =
+            new PositiveDefiniteMatrixPredicate();
+
+    /**
+     * A matrix factory that produces zero {@link Basic2DMatrix}.
+     */
+    public static final MatrixFactory<Basic2DMatrix> BASIC_2D =
+            new MatrixFactory<Basic2DMatrix>() {
+                @Override
+                public Basic2DMatrix apply(int rows, int columns) {
+                    return Basic2DMatrix.zero(rows, columns);
+                }
+            };
+
+    /**
+     * A matrix factory that produces zero {@link Basic1DMatrix}.
+     */
+    public static final MatrixFactory<Basic1DMatrix> BASIC_1D =
+            new MatrixFactory<Basic1DMatrix>() {
+                @Override
+                public Basic1DMatrix apply(int rows, int columns) {
+                    return Basic1DMatrix.zero(rows, columns);
+                }
+            };
+
+    /**
+     * A default matrix factory for dense matrices.
+     */
+    public static final MatrixFactory<Basic2DMatrix> DENSE = BASIC_2D;
+
+    /**
+     * A matrix factory that produces zero {@link CCSMatrix}.
+     */
+    public static final MatrixFactory<CCSMatrix> CCS =
+            new MatrixFactory<CCSMatrix>() {
+                @Override
+                public CCSMatrix apply(int rows, int columns) {
+                    return CCSMatrix.zero(rows, columns);
+                }
+            };
+
+    /**
+     * A matrix factory that produces zero {@link CRSMatrix}.
+     */
+    public static final MatrixFactory<CRSMatrix> CRS =
+            new MatrixFactory<CRSMatrix>() {
+                @Override
+                public CRSMatrix apply(int rows, int columns) {
+                    return CRSMatrix.zero(rows, columns);
+                }
+            };
+
+    /**
+     * A default factory for sparse matrices.
+     */
+    public static final MatrixFactory<CRSMatrix> SPARSE = CRS;
+
+    /**
+     * A default factory for sparse row-major matrices.
+     */
+    public static final MatrixFactory<CRSMatrix> SPARSE_ROW_MAJOR = CRS;
+
+    /**
+     * A default factory for sparse column-major matrices.
+     */
+    public static final MatrixFactory<CCSMatrix> SPARSE_COLUMN_MAJOR = CCS;
+
+    public static final MatrixFactory<?>[] CONVERTERS = {
+            BASIC_2D, BASIC_1D, CRS, CCS
+    };
+
+    /**
+     * Increases each element of matrix by <code>1</code>.
+     */
+    public static final MatrixFunction INC_FUNCTION = new MatrixFunction() {
+        @Override
+        public double evaluate(int i, int j, double value) {
+            return value + 1.0;
+        }
+    };
+
+    /**
+     * Decreases each element of matrix by <code>1</code>.
+     */
+    public static final MatrixFunction DEC_FUNCTION = new MatrixFunction() {
+        @Override
+        public double evaluate(int i, int j, double value) {
+            return value - 1.0;
+        }
+    };
+
+    /**
+     * Inverts each element of matrix.
+     */
+    public static final MatrixFunction INV_FUNCTION = new MatrixFunction() {
+        @Override
+        public double evaluate(int i, int j, double value) {
+            return -value;
+        }
+    };
+
+    private Matrices() {}
+
     private static class SymmetricMatrixPredicate
             implements AdvancedMatrixPredicate {
 
@@ -293,125 +412,6 @@ public final class Matrices {
             return true;
         }
     }
-
-    /**
-     * Checks whether the matrix is a
-     * <a href="http://mathworld.wolfram.com/SymmetricMatrix.html">symmetric
-     * matrix</a>.
-     */
-    public static final AdvancedMatrixPredicate SYMMETRIC_MATRIX =
-            new SymmetricMatrixPredicate();
-
-    /**
-     * Checks whether the matrix is a
-     * <a href="http://en.wikipedia.org/wiki/Diagonally_dominant_matrix">diagonally dominant matrix</a>.
-     */
-    public static final AdvancedMatrixPredicate DIAGONALLY_DOMINANT_MATRIX =
-            new DiagonallyDominantPredicate();
-
-    /**
-     * Checks whether the matrix is positive definite.
-     */
-    public static final AdvancedMatrixPredicate POSITIVE_DEFINITE_MATRIX =
-            new PositiveDefiniteMatrixPredicate();
-
-    /**
-     * A matrix factory that produces zero {@link Basic2DMatrix}.
-     */
-    public static final MatrixFactory<Basic2DMatrix> BASIC_2D =
-        new MatrixFactory<Basic2DMatrix>() {
-            @Override
-            public Basic2DMatrix apply(int rows, int columns) {
-                return Basic2DMatrix.zero(rows, columns);
-            }
-        };
-
-    /**
-     * A matrix factory that produces zero {@link Basic1DMatrix}.
-     */
-    public static final MatrixFactory<Basic1DMatrix> BASIC_1D =
-        new MatrixFactory<Basic1DMatrix>() {
-            @Override
-            public Basic1DMatrix apply(int rows, int columns) {
-                return Basic1DMatrix.zero(rows, columns);
-            }
-        };
-
-    /**
-     * A default matrix factory for dense matrices.
-     */
-    public static final MatrixFactory<Basic2DMatrix> DENSE = BASIC_2D;
-
-    /**
-     * A matrix factory that produces zero {@link CCSMatrix}.
-     */
-    public static final MatrixFactory<CCSMatrix> CCS =
-        new MatrixFactory<CCSMatrix>() {
-            @Override
-            public CCSMatrix apply(int rows, int columns) {
-                return CCSMatrix.zero(rows, columns);
-            }
-        };
-
-    /**
-     * A matrix factory that produces zero {@link CRSMatrix}.
-     */
-    public static final MatrixFactory<CRSMatrix> CRS =
-        new MatrixFactory<CRSMatrix>() {
-            @Override
-            public CRSMatrix apply(int rows, int columns) {
-                return CRSMatrix.zero(rows, columns);
-            }
-        };
-
-    /**
-     * A default factory for sparse matrices.
-     */
-    public static final MatrixFactory<CRSMatrix> SPARSE = CRS;
-
-    /**
-     * A default factory for sparse row-major matrices.
-     */
-    public static final MatrixFactory<CRSMatrix> SPARSE_ROW_MAJOR = CRS;
-
-    /**
-     * A default factory for sparse column-major matrices.
-     */
-    public static final MatrixFactory<CCSMatrix> SPARSE_COLUMN_MAJOR = CCS;
-
-    public static final MatrixFactory<?>[] CONVERTERS = {
-            BASIC_2D, BASIC_1D, CRS, CCS
-    };
-
-    /**
-     * Increases each element of matrix by <code>1</code>.
-     */
-    public static final MatrixFunction INC_FUNCTION = new MatrixFunction() {
-        @Override
-        public double evaluate(int i, int j, double value) {
-            return value + 1.0;
-        }
-    };
-
-    /**
-     * Decreases each element of matrix by <code>1</code>.
-     */
-    public static final MatrixFunction DEC_FUNCTION = new MatrixFunction() {
-        @Override
-        public double evaluate(int i, int j, double value) {
-            return value - 1.0;
-        }
-    };
-
-    /**
-     * Inverts each element of matrix.
-     */
-    public static final MatrixFunction INV_FUNCTION = new MatrixFunction() {
-        @Override
-        public double evaluate(int i, int j, double value) {
-            return -value;
-        }
-    };
 
     /**
      * Creates a const function that evaluates it's argument to given {@code value}.


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava