### PR TITLE
Removing test redundant for org.la4j.inversion.AbstractInverterTest.testInverseInverse_6x6

### DIFF
--- a/src/test/java/org/la4j/inversion/AbstractInverterTest.java
+++ b/src/test/java/org/la4j/inversion/AbstractInverterTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractInverterTest {
         performTest(input, inverterFactory());
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testInverseInverse_5x5 () {
 
         double input[][] = new double[][] {


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.la4j.inversion.AbstractInverterTest.testInverseInverse_6x6, org.la4j.inversion.AbstractInverterTest.testInverseInverse_5x5 are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.la4j.inversion.AbstractInverterTest.testInverseInverse_6x6 while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.