### PR TITLE
Check that index arguments to slice are in-bounds

### DIFF
--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -1264,6 +1264,9 @@ public abstract class Matrix implements Iterable<Double> {
      * @return the sub-matrix of this matrix
      */
     public Matrix slice(int fromRow, int fromColumn, int untilRow, int untilColumn) {
+        ensureIndexArgumentsAreInBounds(fromRow, fromColumn);
+        ensureIndexArgumentsAreInBounds(untilRow, untilColumn);
+
         if (untilRow - fromRow < 0 || untilColumn - fromColumn < 0) {
             fail("Wrong slice range: [" + fromRow + ".." + untilRow + "][" + fromColumn + ".." + untilColumn + "].");
         }
@@ -2156,6 +2159,16 @@ public abstract class Matrix implements Iterable<Double> {
         }
         if (rows == Integer.MAX_VALUE || columns == Integer.MAX_VALUE) {
             fail("Wrong matrix dimensions: use 'Integer.MAX_VALUE - 1' instead.");
+        }
+    }
+
+    protected void ensureIndexArgumentsAreInBounds(int i, int j) {
+        if (i < 0 || i >= rows) {
+            fail(String.format("Bad row argument %d; out of bounds", i));
+        }
+
+        if (j < 0 || j >= columns) {
+            fail(String.format("Bad column argument %d; out of bounds", j));
         }
     }
 

--- a/src/main/java/org/la4j/Matrix.java
+++ b/src/main/java/org/la4j/Matrix.java
@@ -1265,7 +1265,7 @@ public abstract class Matrix implements Iterable<Double> {
      */
     public Matrix slice(int fromRow, int fromColumn, int untilRow, int untilColumn) {
         ensureIndexArgumentsAreInBounds(fromRow, fromColumn);
-        ensureIndexArgumentsAreInBounds(untilRow, untilColumn);
+        ensureIndexArgumentsAreInBounds(untilRow - 1, untilColumn - 1);
 
         if (untilRow - fromRow < 0 || untilColumn - fromColumn < 0) {
             fail("Wrong slice range: [" + fromRow + ".." + untilRow + "][" + fromColumn + ".." + untilColumn + "].");


### PR DESCRIPTION
If the indices were out of bounds, an exception would eventually be thrown but
it would fail on the first index out of bounds, giving a mis-leading message.
Checking at the beginning of the method means the error message can be
more useful.

For example, the following code:

```java
Matrix someMatrix = ... // 10 x 10
someMatrix = someMatrix.slice(0, 0, 15, 15);
```

would give `IndexOutOfBoundsException: 10` despite `10` not being an argument to the method.
With this change, the user will get `IllegalArgumentException: Bad row argument 15; out of bounds` immediately after invocation.