### PR TITLE
Oracle JDK7 is no longer officially supported and not available anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk10
   - openjdk7
+  - openjdk8
+  - openjdk10


### PR DESCRIPTION
Closes #292 .

Oracle JDK7 is no longer officially supported and also no longer downloadable from Oracle JDK site.
Therefore the oracle-jdk7 build was removed from Travis file.

Instead added:
 * Open JDK8
 * Open JDK10
 * Oracle JDK10

References:
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html
 * http://www.oracle.com/technetwork/java/javase/eol-135779.html
 * http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html